### PR TITLE
added dummy image icon for earth god/water god

### DIFF
--- a/units/Summoners/Earth_God.cfg
+++ b/units/Summoners/Earth_God.cfg
@@ -4,6 +4,7 @@
     name= _ "Earth God"
     race=I8 magical
     image="units/summoners-elementals/god-earth.png"
+    image_icon="units/summoners-elementals/god-earth.png"
     hitpoints=85
     movement_type=mountainfoot
     movement=4

--- a/units/Summoners/Water_God.cfg
+++ b/units/Summoners/Water_God.cfg
@@ -4,6 +4,7 @@
     name= _ "Water God"
     race=I8 magical
     image="units/summoners-elementals/water-god1.png"
+    image_icon="units/summoners-elementals/water-god1.png"
     profile="portraits/al-kamija/watergod.png"
     hitpoints=60
     movement_type=swimmer


### PR DESCRIPTION
added dummy image icon for earth god/water god (due to amulet of metamorph causing units to keep the old types' image icons after transforming into earth/water gods)