### PR TITLE
Tank attack rename patch

### DIFF
--- a/units/Runemasters/Dwarvish_Tank.cfg
+++ b/units/Runemasters/Dwarvish_Tank.cfg
@@ -14,7 +14,7 @@
     advances_to=EoMa_Pacificator
     cost=46
     usage=fighter
-    description={NO_DESCR_AVAILABLE}+{SPECIAL_NOTES}+{SPECIAL_NOTES_CHARGE}
+    description=_"Dwarvish Tanks are the heavier variety of the striding machines, equipped with cannons capable of easily shattering most kinds of fortifications or cover. They are used both as mobile siege engines, and to deal with small squads of infantry."+{SPECIAL_NOTES}+{SPECIAL_NOTES_CHARGE}
     die_sound={SOUND_LIST:DWARF_DIE}
     {DEFENSE_ANIM_DIRECTIONAL "units/runemasters-machines/tank2.png" "units/runemasters-machines/tank2.png" "units/runemasters-machines/tank-ne2.png" "units/runemasters-machines/tank-ne2.png" {SOUND_LIST:DWARF_HIT} }
     {DEFENSE_ANIM_FILTERED "units/runemasters-machines/tank-s2.png" "units/runemasters-machines/tank-s2.png" {SOUND_LIST:DWARF_HIT} direction=s}
@@ -48,7 +48,7 @@
     [/attack]
     [attack]
         name=cannons
-        description=_"explosive ammo"
+        description=_"cannons"
         icon=attacks/bullet.png
         type=fire
         range=ranged
@@ -60,7 +60,7 @@
     [/attack]
     [attack]
         name=cannons2
-        description=_"piercing ammo"
+        description=_"machine gun"
         icon=attacks/mg.png
         type=pierce
         range=ranged

--- a/units/Runemasters/Pacificator.cfg
+++ b/units/Runemasters/Pacificator.cfg
@@ -49,7 +49,7 @@
     [/attack]
     [attack]
         name=cannons
-        description=_"explosive ammo"
+        description=_"cannons"
         icon=attacks/bullet.png
         type=fire
         range=ranged
@@ -61,7 +61,7 @@
     [/attack]
     [attack]
         name=cannons2
-        description=_"piercing ammo"
+        description=_"machine gun"
         icon=attacks/mg.png
         type=pierce
         range=ranged

--- a/units/Runemasters/Striding_Machine.cfg
+++ b/units/Runemasters/Striding_Machine.cfg
@@ -48,7 +48,7 @@
     [/attack]
     [attack]
         name=cannons
-        description=_"mini-cannons"
+        description=_"machine gun"
 		icon=attacks/mg.png
         type=pierce
         range=ranged


### PR DESCRIPTION
-renamed "mini-cannons"/"piercing ammo" to "machine gun"
-renamed "explosive ammo" to "cannons"
-added the lvl2 tank description