### PR TITLE
Bone beast line animation tweaks

### DIFF
--- a/units/Destroyers/Bone_Giant.cfg
+++ b/units/Destroyers/Bone_Giant.cfg
@@ -80,23 +80,22 @@
         [filter_attack]
             name=head
         [/filter_attack]
-        start_time=-200
-        [if]
-            hits=yes
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/giant.png"
-                sound=staff.wav
-            [/frame]
-        [/if]
-        [else]
-            hits=no
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/giant.png"
-                sound={SOUND_LIST:MISS}
-            [/frame]
-        [/else]
+        start_time=-1450
+
+        [frame]
+            image="units/destroyers-beasts/giant.png:600"
+            offset=0.0~-0.3:400,-0.3~-0.3:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/giant.png:1050"
+            offset=-0.3~-0.2.0:200,-0.2~0.0:150,0.0~0.6:400,1.0~0.5:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/giant.png:400"
+            offset=0.5~0.0:400
+        [/frame]
+
+        {SOUND:HIT_AND_MISS staff.wav {SOUND_LIST:MISS} -100}
     [/attack_anim]
 	[attack_anim]
         [filter_attack]

--- a/units/Destroyers/Bone_Golem.cfg
+++ b/units/Destroyers/Bone_Golem.cfg
@@ -79,23 +79,22 @@
         [filter_attack]
             name=head
         [/filter_attack]
-        start_time=-200
-        [if]
-            hits=yes
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/bonegolem.png"
-                sound=staff.wav
-            [/frame]
-        [/if]
-        [else]
-            hits=no
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/bonegolem.png"
-                sound={SOUND_LIST:MISS}
-            [/frame]
-        [/else]
+        start_time=-1450
+
+        [frame]
+            image="units/destroyers-beasts/bonegolem.png:600"
+            offset=0.0~-0.3:400,-0.3~-0.3:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/bonegolem.png:1050"
+            offset=-0.3~-0.2.0:200,-0.2~0.0:150,0.0~0.6:400,1.0~0.5:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/bonegolem.png:400"
+            offset=0.5~0.0:400
+        [/frame]
+
+        {SOUND:HIT_AND_MISS staff.wav {SOUND_LIST:MISS} -100}
     [/attack_anim]
 	[attack_anim]
         [filter_attack]

--- a/units/Destroyers/Bone_Moloch.cfg
+++ b/units/Destroyers/Bone_Moloch.cfg
@@ -82,23 +82,22 @@
         [filter_attack]
             name=head
         [/filter_attack]
-        start_time=-200
-        [if]
-            hits=yes
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/moloch.png"
-                sound=staff.wav
-            [/frame]
-        [/if]
-        [else]
-            hits=no
-            [frame]
-                duration=200
-                image="units/destroyers-beasts/moloch.png"
-                sound={SOUND_LIST:MISS}
-            [/frame]
-        [/else]
+        start_time=-1450
+
+        [frame]
+            image="units/destroyers-beasts/moloch.png:600"
+            offset=0.0~-0.3:400,-0.3~-0.3:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/moloch.png:1050"
+            offset=-0.3~-0.2.0:200,-0.2~0.0:150,0.0~0.6:400,1.0~0.5:200
+        [/frame]
+        [frame]
+            image="units/destroyers-beasts/moloch.png:400"
+            offset=0.5~0.0:400
+        [/frame]
+
+        {SOUND:HIT_AND_MISS staff.wav {SOUND_LIST:MISS} -100}
     [/attack_anim]
 	[attack_anim]
         [filter_attack]
@@ -123,4 +122,16 @@
         [/else]
     [/attack_anim]
     {DESTROYER_RECRUIT_ANIM_HUGE 35}
+    [event]
+        name=attacker_hits
+        first_time_only=no
+		id=eoma_quake_event_moloch
+        [filter]
+            type=EoMa_Moloch
+        [/filter]
+        [filter_attack]
+            name=head
+        [/filter_attack]
+        {QUAKE silence.ogg}
+    [/event]
 [/unit_type]


### PR DESCRIPTION
since the bone golem/bone giant/moloch's headbutt animation felt quite underwhelming, I decided to make them feel more powerful:
-all of the mentioned units' headbutt animations have a windup, like dharma'rhami's tackle animation now does
-moloch has a quake effect on hit (which is quite fitting, given the amount of damage the headbutt attack deals)