### PR TITLE
Make anti-mech translatable

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1702,7 +1702,7 @@ Unlike the 'illuminates' ability, this ability affects the damage bonus/penalty 
 #define WEAPON_SPECIAL_EOMA_ANTIMECH VALUE
     [damage]
         id=eoma_antimech{VALUE}
-        name= _ "anti-mech"+" +{VALUE}"
+        name= _ "anti-mech"+" +"+{VALUE}
         description=_"This attacks deals additional {VALUE} points of damage against mechanical units."
         apply_to=self
         add={VALUE}

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1702,7 +1702,7 @@ Unlike the 'illuminates' ability, this ability affects the damage bonus/penalty 
 #define WEAPON_SPECIAL_EOMA_ANTIMECH VALUE
     [damage]
         id=eoma_antimech{VALUE}
-        name= _ "anti-mech +{VALUE}"
+        name= _ "anti-mech"+" +{VALUE}"
         description=_"This attacks deals additional {VALUE} points of damage against mechanical units."
         apply_to=self
         add={VALUE}


### PR DESCRIPTION
{MACRO} substitution aren't translatable within a string (there are tricks, but it is not practical), must be a variable or left outside the string.
The change uses the same method as "heals"+" +{VALUE}" on ABILITY_EOMA_HEAL
I know it's not very translate-friendly to use this method instead of the variable because we can't change the order of anti-mech + number, for some languages, but at least translation is possible.