### PR TITLE
Dimensional Gate: Allow eoma_delete_advancement multiple times

### DIFF
--- a/utils/soul-catcher.cfg
+++ b/utils/soul-catcher.cfg
@@ -120,6 +120,7 @@
         [/filter]
         [object]
             id=eoma_delete_advancement
+            take_only_once=no
             [effect]
                 apply_to=remove_advancement
                 types=EoMa_Rhami,EoMa_Fire_Elemental,EoMa_Water_Elemental,EoMa_Air_Elemental,EoMa_Earth_Elemental,EoMa_Jinn,EoMa_RhamiKai,EoMa_RhamiDatu,EoMa_Fire_Avatar,EoMa_Water_Avatar,EoMa_Air_Avatar,EoMa_Earth_Avatar,EoMa_Great_Jinn,EoMa_Efreet


### PR DESCRIPTION
By default, the same object id cannot be reused during a single scenario.