### PR TITLE
Properly use flying attribute

### DIFF
--- a/units/Destroyers/Cyclops_Necromancer.cfg
+++ b/units/Destroyers/Cyclops_Necromancer.cfg
@@ -13,7 +13,7 @@
     image="units/destroyers-cyclops/cyclop2alt.png"
     ellipse="misc/ellipse"
     hitpoints=40
-    movement_type=woodlandfloat#placeholder movetype, just to give flies=yes
+    flying=yes
     movement=6
     experience=100
     level=2

--- a/units/Kharos/Inspired.cfg
+++ b/units/Kharos/Inspired.cfg
@@ -31,7 +31,7 @@
         cold=100
         arcane=60
     [/resistance]
-    flies=true
+    flying=yes
     [defense]
         deep_water=70
         shallow_water=70

--- a/units/Kharos/Sister_of_Light.cfg
+++ b/units/Kharos/Sister_of_Light.cfg
@@ -34,7 +34,7 @@
         cold=100
         arcane=60
     [/resistance]
-    flies=true
+    flying=yes
     [defense]
         deep_water=70
         shallow_water=70

--- a/units/Sky_Kingdom/Chronomancer.cfg
+++ b/units/Sky_Kingdom/Chronomancer.cfg
@@ -5,7 +5,7 @@
     image="units/skykingdom-magi/enlightened-chronomancer1.png"
     race=human
 
-    flies=true
+    flying=yes
     hitpoints=62
     movement_type=I8 subversivemage
     movement=6

--- a/units/Sky_Kingdom/Master_of_Elements.cfg
+++ b/units/Sky_Kingdom/Master_of_Elements.cfg
@@ -7,7 +7,7 @@
 
     hitpoints=68
     movement_type=smallfoot
-    flies=yes
+    flying=yes
     movement=5
     experience=200
     level=4

--- a/units/Sky_Kingdom/Void_Mage.cfg
+++ b/units/Sky_Kingdom/Void_Mage.cfg
@@ -7,7 +7,7 @@
     small_profile="portraits/sky_kingdom/voidmage.png~SCALE(205,205)"
     race=human
 
-    flies=true
+    flying=yes
     hitpoints=58
     movement_type=I8 subversivemage
     movement=6

--- a/units/Summoners/Fire_Elemental.cfg
+++ b/units/Summoners/Fire_Elemental.cfg
@@ -8,7 +8,7 @@
     halo="halo/fire2-halo.png~SCALE(90,90)"
     hitpoints=35
     movement_type=smallfoot
-    flies=yes
+    flying=yes
     movement=5
     experience=42
     level=1

--- a/units/Summoners/Summons_Master.cfg
+++ b/units/Summoners/Summons_Master.cfg
@@ -9,7 +9,7 @@
 
     hitpoints=72
     movement_type=smallfoot
-    flies=true
+    flying=yes
     movement=5
     experience=200
     level=4

--- a/units/Tharis/Great_Warlock.cfg
+++ b/units/Tharis/Great_Warlock.cfg
@@ -9,7 +9,7 @@
 
     hitpoints=54
     movement_type=I8 defoot
-    flies=yes
+    flying=yes
     movement=5
     experience=216
     level=3
@@ -76,7 +76,7 @@
         unwalkable=70
     [/defense]
     [movetype]
-        flies=true
+        flying=yes
     [/movetype]
     [movement_costs]
         deep_water=2

--- a/units/Tharis/Master_of_Darkness.cfg
+++ b/units/Tharis/Master_of_Darkness.cfg
@@ -42,7 +42,7 @@
         village=40
     [/defense]
     [movetype]
-        flies=true
+        flying=yes
     [/movetype]
     [movement_costs]
         deep_water=1

--- a/units/Tharis/Matriarch_of_Frost.cfg
+++ b/units/Tharis/Matriarch_of_Frost.cfg
@@ -12,7 +12,7 @@
     hitpoints=55
     movement_type=I8 defoot
     movement=5
-    flies=true
+    flying=yes
     experience=150
     level=3
     alignment=chaotic


### PR DESCRIPTION
- [unit]flies does not exist, it should be flying.
- [movetype]flies is deprecated, it should also be flying, or just [unit]flying.

In Wesnoth 1.16, there is no need for any placeholder movetypes in order to define a unit as flying.