### PR TITLE
fix chronoaura use filter_self instead of [filter_student]

### DIFF
--- a/utils/chronoaura.cfg
+++ b/utils/chronoaura.cfg
@@ -23,17 +23,15 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         affect_allies=no
         affect_enemies=yes
         [affect_adjacent]
-            [filter]
-            [/filter]
         [/affect_adjacent]
         #using filter self is intentional, as the "self" in this case is the unit being debuffed since it's a weapon special being given to units via aura
-        [filter_self]
+        [filter_student]
             [filter_weapon]
                 [not]
                     special_id=eoma_alwayshits
                 [/not]
             [/filter_weapon]
-        [/filter_self]
+        [/filter_student]
     [/chance_to_hit]
     [chance_to_hit]
         id=eoma_chronoaura_allies_and_self
@@ -171,17 +169,14 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         affect_allies=no
         affect_enemies=yes
         [affect_adjacent]
-            [filter]
-            [/filter]
         [/affect_adjacent]
-        #using filter self is intentional, as the "self" in this case is the unit being debuffed since it's a weapon special being given to units via aura
-        [filter_self]
+        [filter_student]
             [filter_weapon]
                 [not]
                     special_id=eoma_alwayshits
                 [/not]
             [/filter_weapon]
-        [/filter_self]
+        [/filter_student]
     [/chance_to_hit]
     [chance_to_hit]
         id=eoma_chronoauractive_cth_allies_and_self
@@ -191,8 +186,6 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         affect_allies=yes
         affect_enemies=no
         [affect_adjacent]
-            [filter]
-            [/filter]
         [/affect_adjacent]
     [/chance_to_hit]
     [leadership]
@@ -201,8 +194,6 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         cumulative=yes
         affect_self=no
         [affect_adjacent]
-            [filter]
-            [/filter]
         [/affect_adjacent]
     [/leadership]
 #enddef

--- a/utils/chronoaura.cfg
+++ b/utils/chronoaura.cfg
@@ -24,7 +24,7 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         affect_enemies=yes
         [affect_adjacent]
         [/affect_adjacent]
-        #using filter self is intentional, as the "self" in this case is the unit being debuffed since it's a weapon special being given to units via aura
+        #using filter student is intentional, as the "student" in this case is the unit being debuffed since it's a weapon special being given to units via aura
         [filter_student]
             [filter_weapon]
                 [not]


### PR DESCRIPTION
when special is implemented in [abilities], the unit who has debuff is filtered by [filter_student] instead of [filter_self] who point the owner of ability anddon't support [filter_weapon]