### PR TITLE
Use the 'active' version of special_id and special_type

### DIFF
--- a/units/Sky_Kingdom/Mirrorshield.cfg
+++ b/units/Sky_Kingdom/Mirrorshield.cfg
@@ -181,7 +181,7 @@ The warrior's bravery and quick thinking earned him a reprieve from the Master C
     [/attack_anim]
 
 #define DEFLECT_MAGIC_FILTER
-    special_id=magical,eoma_enchanted,eoma_magical_offensive,eoma_magical_defensive
+    special_id_active=magical,eoma_enchanted,eoma_magical_offensive,eoma_magical_defensive
     type=fire,cold,arcane
     [not]
         type=secret

--- a/units/Sky_Kingdom/Mu.cfg
+++ b/units/Sky_Kingdom/Mu.cfg
@@ -34,7 +34,7 @@
     [death]
         [filter_attack]
             [not]
-                special_type=plague
+                special_type_active=plague
             [/not]
         [/filter_attack]
         start_time=-100

--- a/units/Sky_Kingdom/Um.cfg
+++ b/units/Sky_Kingdom/Um.cfg
@@ -47,7 +47,7 @@
     [death]
         [filter_attack]
             [not]
-                special_type=plague
+                special_type_active=plague
             [/not]
         [/filter_attack]
         start_time=0

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -144,7 +144,7 @@
     id=eoma_hitandrunspecial_event{VALUE}
     first_time_only=no
     [filter_attack]
-        special_id=eoma_hitandrunspecial{VALUE}
+        special_id_active=eoma_hitandrunspecial{VALUE}
     [/filter_attack]
     [filter_condition]
         [have_unit]
@@ -358,7 +358,7 @@ Chance to hit secondary target: " + {CHANCETOHIT} + "%"+" "+{EOMA_NO_RPG}
     id=eoma_areaeffect_event_{CHANCETOHIT}
     first_time_only=no
     [filter_attack]
-        special_id=eoma_areaeffectrandom_{CHANCETOHIT}
+        special_id_active=eoma_areaeffectrandom_{CHANCETOHIT}
     [/filter_attack]
 #ifdef MULTIPLAYER
     [filter_condition]
@@ -506,7 +506,7 @@ This ability works even against allies."
     id=eoma_areaeffect_event
     first_time_only=no
     [filter_attack]
-        special_id=eoma_areaeffect
+        special_id_active=eoma_areaeffect
     [/filter_attack]
 #ifdef MULTIPLAYER
     [filter_condition]
@@ -666,7 +666,7 @@ This ability works even against allies."
     [/filter]
 
     [filter_second_attack]
-        special_id=eoma_swallow{VALUE}
+        special_id_active=eoma_swallow{VALUE}
     [/filter_second_attack]
 
     [heal_unit]
@@ -728,7 +728,7 @@ The amount of hitpoints gained:"+" +"+{VALUE}+" "+{EOMA_NO_RPG}
     [/filter]
 
     [filter_second_attack]
-        special_id=eoma_collector{VALUE}
+        special_id_active=eoma_collector{VALUE}
     [/filter_second_attack]
 
     #increase max hp
@@ -1145,7 +1145,7 @@ The amount of hitpoints gained:"+" +"+{VALUE}+" "+{EOMA_NO_RPG}
         [/not]
     [/filter_second]
     [filter_attack]
-        special_id=eoma_immoblize
+        special_id_active=eoma_immoblize
     [/filter_attack]
 
     #heavily simplified immobilize code, this also fixes the "immobilize does not work if side 2 immobilizes side 1 unit" (or any other side with higher number immobilizing a unit from lower side)
@@ -1220,7 +1220,7 @@ The amount of hitpoints gained:"+" +"+{VALUE}+" "+{EOMA_NO_RPG}
         [/not]
     [/filter_second]
     [filter_attack]
-        special_id=eoma_dazzle
+        special_id_active=eoma_dazzle
     [/filter_attack]
 
     # Record information about the dazzling
@@ -1541,7 +1541,7 @@ When the opponent is defeated, the attacker with this ability moves to the oppon
 #endif
 
     [filter_second_attack]
-        special_id=eoma_supercharge
+        special_id_active=eoma_supercharge
     [/filter_second_attack]
 
     [kill]

--- a/utils/allaround.cfg
+++ b/utils/allaround.cfg
@@ -79,7 +79,7 @@ Chance to hit secondary target: " + {CHANCETOHIT} + "%"+" "+{EOMA_NO_RPG}
         [filter_opponent]
             [filter_weapon]
                 [not]
-                    special_type=berserk
+                    special_type_active=berserk
                 [/not]
             [/filter_weapon]
         [/filter_opponent]
@@ -94,11 +94,11 @@ Chance to hit secondary target: " + {CHANCETOHIT} + "%"+" "+{EOMA_NO_RPG}
     first_time_only=no
     id=eoma_allaround_event_{CHANCETOHIT}
     [filter_attack]
-        special_id=eoma_allaround_{CHANCETOHIT}
+        special_id_active=eoma_allaround_{CHANCETOHIT}
     [/filter_attack]
     [filter_second_attack]
         [not]
-            special_type=berserk
+            special_type_active=berserk
         [/not]
     [/filter_second_attack]
 #ifdef MULTIPLAYER

--- a/utils/animations-barbarians.cfg
+++ b/utils/animations-barbarians.cfg
@@ -79,7 +79,7 @@
     [death]
         [filter_attack]
             [not]
-                special_type=plague
+                special_type_active=plague
             [/not]
         [/filter_attack]
         start_time=-100

--- a/utils/awake.cfg
+++ b/utils/awake.cfg
@@ -45,15 +45,15 @@ Doesn't work on units killed by attacks with plague/supercharge/swallow specials
     [/filter]
     [filter_second_attack]
         [not]
-            special_id=eoma_supercharge
+            special_id_active=eoma_supercharge
             [or]
-                special_type=plague
+                special_type_active=plague
             [/or]
             [or]
-                special_id=eoma_swallow_filter
+                special_id_active=eoma_swallow_filter
             [/or]
             [or]
-                special_id=eoma_kamikaze
+                special_id_active=eoma_kamikaze
             [/or]
         [/not]
     [/filter_second_attack]

--- a/utils/banish.cfg
+++ b/utils/banish.cfg
@@ -38,7 +38,7 @@
     name=attacker hits
 
     [filter_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_attack]
     [filter]
         level=2
@@ -79,7 +79,7 @@
     name=attacker hits
 
     [filter_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_attack]
     [filter]
         level=3
@@ -113,7 +113,7 @@
     name=attacker hits
 
     [filter_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_attack]
     [filter]
         level=4
@@ -144,7 +144,7 @@
     name=defender hits
 
     [filter_second_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_second_attack]
     [filter_second]
         level=2
@@ -185,7 +185,7 @@
     name=defender hits
 
     [filter_second_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_second_attack]
     [filter_second]
         level=3
@@ -219,7 +219,7 @@
     name=defender hits
 
     [filter_second_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_second_attack]
     [filter_second]
         level=4
@@ -250,7 +250,7 @@
     id=eoma_banish_event3
     name=attack end
     [filter_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_attack]
 
     {IF_VAR touched equals yes (
@@ -273,7 +273,7 @@
     id=eoma_banish_event4
     name=attack end
     [filter_second_attack]
-        special_id=eoma_banish
+        special_id_active=eoma_banish
     [/filter_second_attack]
 
     {IF_VAR touched equals yes (

--- a/utils/beam.cfg
+++ b/utils/beam.cfg
@@ -87,7 +87,7 @@ Chance to hit secondary targets: 100% when primary attack hits."+" "+{EOMA_NO_RP
     first_time_only=no
 
     [filter_attack]
-        special_id=eoma_beam
+        special_id_active=eoma_beam
     [/filter_attack]
 #ifdef MULTIPLAYER
     [filter_condition]

--- a/utils/bleed.cfg
+++ b/utils/bleed.cfg
@@ -44,7 +44,7 @@
     [/filter_second]
 
     [filter_attack]
-        special_id=eoma_bleed
+        special_id_active=eoma_bleed
     [/filter_attack]
 
     {VARIABLE second_unit.status.bleeding yes}
@@ -109,7 +109,7 @@
     [/filter]
 
     [filter_second_attack]
-        special_id=eoma_bleed
+        special_id_active=eoma_bleed
     [/filter_second_attack]
 
     {VARIABLE unit.status.bleeding yes}

--- a/utils/chancetohit.cfg
+++ b/utils/chancetohit.cfg
@@ -29,7 +29,7 @@
         [filter_opponent]
             [filter_weapon]
                 [not]
-                    special_type=berserk
+                    special_type_active=berserk
                 [/not]
             [/filter_weapon]
         [/filter_opponent]
@@ -163,7 +163,7 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=magical,eoma_magical_defensive,eoma_magical_offensive
+                special_id_active=magical,eoma_magical_defensive,eoma_magical_offensive
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -173,7 +173,7 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=eoma_enchanted
+                special_id_active=eoma_enchanted
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -189,7 +189,7 @@
         active_on=offense
         [filter_opponent]
             [filter_weapon]
-                special_id=magical,eoma_magical_defensive,eoma_magical_offensive
+                special_id_active=magical,eoma_magical_defensive,eoma_magical_offensive
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -201,7 +201,7 @@
         active_on=offense
         [filter_opponent]
             [filter_weapon]
-                special_id=eoma_enchanted
+                special_id_active=eoma_enchanted
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]

--- a/utils/chronoaura.cfg
+++ b/utils/chronoaura.cfg
@@ -28,7 +28,7 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         [filter_student]
             [filter_weapon]
                 [not]
-                    special_id=eoma_alwayshits
+                    special_id_active=eoma_alwayshits
                 [/not]
             [/filter_weapon]
         [/filter_student]
@@ -173,7 +173,7 @@ To cast the spell right-click the unit and select 'Activate Aura'."
         [filter_student]
             [filter_weapon]
                 [not]
-                    special_id=eoma_alwayshits
+                    special_id_active=eoma_alwayshits
                 [/not]
             [/filter_weapon]
         [/filter_student]

--- a/utils/cleave.cfg
+++ b/utils/cleave.cfg
@@ -136,7 +136,7 @@ Base damage multiplier:"+" "+{DISPLAYVALUE}+"%"+" "+{EOMA_NO_RPG}
         [filter_opponent]
             [filter_weapon]
                 [not]
-                    special_type=berserk
+                    special_type_active=berserk
                 [/not]
             [/filter_weapon]
         [/filter_opponent]
@@ -151,11 +151,11 @@ Base damage multiplier:"+" "+{DISPLAYVALUE}+"%"+" "+{EOMA_NO_RPG}
     first_time_only=no
     id=eoma_cleave{DISPLAYVALUE}_event
     [filter_attack]
-        special_id=eoma_cleave{DISPLAYVALUE}
+        special_id_active=eoma_cleave{DISPLAYVALUE}
     [/filter_attack]
     [filter_second_attack]
         [not]
-            special_type=berserk
+            special_type_active=berserk
         [/not]
     [/filter_second_attack]
 #ifdef MULTIPLAYER
@@ -224,11 +224,11 @@ Base damage multiplier:"+" "+{DISPLAYVALUE}+"%"+" "+{EOMA_NO_RPG}
     first_time_only=no
     id=eoma_cleave{DISPLAYVALUE}_event2
     [filter_second_attack]
-        special_id=eoma_cleave{DISPLAYVALUE}
+        special_id_active=eoma_cleave{DISPLAYVALUE}
     [/filter_second_attack]
     [filter_attack]
         [not]
-            special_type=berserk
+            special_type_active=berserk
         [/not]
     [/filter_attack]
 #ifdef MULTIPLAYER

--- a/utils/doubleattack.cfg
+++ b/utils/doubleattack.cfg
@@ -18,7 +18,7 @@
     id=eoma_splitfire_event
     first_time_only=no
     [filter_attack]
-        special_id=eoma_splitfire
+        special_id_active=eoma_splitfire
     [/filter_attack]
 
     {IF_VAR unit.variables.eoma_splitfire_active boolean_equals true (

--- a/utils/dragon_breath.cfg
+++ b/utils/dragon_breath.cfg
@@ -26,7 +26,7 @@ Chance to hit secondary target: 60%"+" "+{EOMA_NO_RPG}
     id=eoma_dbreath_event1
     first_time_only=no
     [filter_attack]
-        special_id=eoma_dbreath
+        special_id_active=eoma_dbreath
     [/filter_attack]
 #ifdef MULTIPLAYER
     [filter_condition]

--- a/utils/growing-fury.cfg
+++ b/utils/growing-fury.cfg
@@ -23,7 +23,7 @@
     id=eoma_growingfury{ARRAY}{ADD}_event1
     first_time_only=no
     [filter_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_attack]
 
     {VARIABLE growingfury_counter 1}
@@ -35,7 +35,7 @@
     first_time_only=no
     id=eoma_growingfury{ARRAY}{ADD}_event2
     [filter_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_attack]
 
     [if]
@@ -64,7 +64,7 @@
     id=eoma_growingfury{ARRAY}{ADD}_event3
     first_time_only=no
     [filter_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_attack]
 
     [object]
@@ -89,7 +89,7 @@
     id=eoma_growingfury{ARRAY}{ADD}_event4
     first_time_only=no
     [filter_second_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_second_attack]
 
     {VARIABLE growingfury2_counter 1}
@@ -101,7 +101,7 @@
     first_time_only=no
     id=eoma_growingfury{ARRAY}{ADD}_event5
     [filter_second_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_second_attack]
 
     [if]
@@ -130,7 +130,7 @@
     id=eoma_growingfury{ARRAY}{ADD}_event6
     first_time_only=no
     [filter_second_attack]
-        special_id=eoma_growingfury{ARRAY}{ADD}
+        special_id_active=eoma_growingfury{ARRAY}{ADD}
     [/filter_second_attack]
 
     [object]

--- a/utils/plague_destroyers.cfg
+++ b/utils/plague_destroyers.cfg
@@ -20,7 +20,7 @@
             [/filter_location]
         [/filter]
         [filter_second_attack]
-            special_type=plague
+            special_type_active=plague
         [/filter_second_attack]
 
         [store_unit]

--- a/utils/resistance.cfg
+++ b/utils/resistance.cfg
@@ -485,7 +485,7 @@
         description= _ "This unit gains +5% to all resistances, up to a maximum of 60%, when using a weapon with the 'shielded' special."
         affect_self=yes
         [filter_weapon]
-            special_id=eoma_shielded_special
+            special_id_active=eoma_shielded_special
         [/filter_weapon]
     [/resistance]
 #enddef

--- a/utils/sculpt.cfg
+++ b/utils/sculpt.cfg
@@ -30,7 +30,7 @@
     [/filter_condition]
 #endif
     [filter_attack]
-        special_id=eoma_sculpts
+        special_id_active=eoma_sculpts
     [/filter_attack]
 
     # Record information about the petrifying
@@ -56,7 +56,7 @@
     [/filter_condition]
 #endif
     [filter_second_attack]
-        special_id=eoma_sculpts
+        special_id_active=eoma_sculpts
     [/filter_second_attack]
 
     # Record information about the petrifying

--- a/utils/triplestrike.cfg
+++ b/utils/triplestrike.cfg
@@ -13,7 +13,7 @@ Chance to hit secondary target: 40%"+" "+{EOMA_NO_RPG}
         [filter_opponent]
             [filter_weapon]
                 [not]
-                    special_type=berserk
+                    special_type_active=berserk
                 [/not]
             [/filter_weapon]
         [/filter_opponent]
@@ -28,11 +28,11 @@ Chance to hit secondary target: 40%"+" "+{EOMA_NO_RPG}
     first_time_only=no
     id=eoma_triplestrike_event
     [filter_attack]
-        special_id=eoma_triplestrike
+        special_id_active=eoma_triplestrike
     [/filter_attack]
     [filter_second_attack]
         [not]
-            special_type=berserk
+            special_type_active=berserk
         [/not]
     [/filter_second_attack]
 #ifdef MULTIPLAYER
@@ -113,7 +113,7 @@ Chance to hit secondary target: 40%"+" "+{EOMA_NO_RPG}
                                     x,y=$x1,$y1
                                     [and]
                                         [has_attack]
-                                            special_type_active=drains
+                                            special_type=drains
                                         [/has_attack]
                                     [/and]
                                 [/have_unit]
@@ -155,11 +155,11 @@ Chance to hit secondary target: 40%"+" "+{EOMA_NO_RPG}
     first_time_only=no
     id=eoma_triplestrike_event2
     [filter_second_attack]
-        special_id=eoma_triplestrike
+        special_id_active=eoma_triplestrike
     [/filter_second_attack]
     [filter_attack]
         [not]
-            special_type=berserk
+            special_type_active=berserk
         [/not]
     [/filter_attack]
 #ifdef MULTIPLAYER
@@ -240,7 +240,7 @@ Chance to hit secondary target: 40%"+" "+{EOMA_NO_RPG}
                                     x,y=$x2,$y2
                                     [and]
                                         [has_attack]
-                                            special_type_active=drains
+                                            special_type=drains
                                         [/has_attack]
                                     [/and]
                                 [/have_unit]


### PR DESCRIPTION
This is to take into account the activity of the filtered weapon; otherwise, only its possession will be taken into account.