### PR TITLE
use sub= in weapon specials instead od add=-

### DIFF
--- a/utils/chancetohit.cfg
+++ b/utils/chancetohit.cfg
@@ -159,7 +159,7 @@
         id=eoma_magic_counter
         name= _ "magic counter"
         description= _ "This attack reduces magical chance to hit of opponents by 20% (down to 50%). It also reduces enchanted chance to hit of opponents by 10% (down to 50% as well)."
-        add=-20
+        sub=20
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
@@ -169,7 +169,7 @@
     [/chance_to_hit]
     [chance_to_hit]
         id=eoma_magic_counter2
-        add=-10
+        sub=10
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
@@ -184,7 +184,7 @@
         id=eoma_magic_dodge
         name= _ "magic dodge"
         description= _ "When used offensively, this attack reduces magical chance to hit of opponents by 20% (down to 50%). It also reduces enchanted chance to hit of opponents by 10% (down to 50% as well)."
-        add=-20
+        sub=20
         apply_to=opponent
         active_on=offense
         [filter_opponent]
@@ -196,7 +196,7 @@
     [chance_to_hit]
         id=eoma_magic_dodge2
         name=""# wmllint: ignore
-        add=-10
+        sub=10
         apply_to=opponent
         active_on=offense
         [filter_opponent]

--- a/utils/runeaura.cfg
+++ b/utils/runeaura.cfg
@@ -196,7 +196,7 @@
     [/resistance]
     [resistance]
         id=eoma_runeauraactive_physical2
-        add=-30
+        sub=30
         max_value=70
         apply_to=blade,pierce,impact
         affect_self=no
@@ -252,7 +252,7 @@
     [/resistance]
     [resistance]
         id=eoma_runeauraactive_physical4
-        add=-30
+        sub=30
         max_value=70
         apply_to=blade,pierce,impact
         affect_self=no


### PR DESCRIPTION
the issue with add= negative, are if two special with same id but two add of diffrent value are active,the special with the geatest value will be choosen, if by exemple we have add=-10 and add=-20, it add=-10 who will be used.

for prevent  this potential issue, use sub= instead, where sub=20 will be used instead of sub=10.